### PR TITLE
twrp-6.0: Remove fw/native-caf from the manifest

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -279,7 +279,7 @@
   <!-- project path="frameworks/ml" name="platform/frameworks/ml" groups="pdk-cw-fs" /> -->
   <!-- project path="frameworks/multidex" name="platform/frameworks/multidex" groups="pdk-cw-fs" /> -->
   <project path="frameworks/native" name="android_frameworks_native" remote="omnirom" revision="android-6.0" groups="pdk" />
-  <project path="frameworks/native-caf" name="android_frameworks_native-caf" remote="omnirom" revision="android-6.0" groups="pdk" />
+  <!-- project path="frameworks/native-caf" name="android_frameworks_native-caf" remote="omnirom" revision="android-6.0" groups="pdk" /> -->
   <!-- project path="frameworks/opt/bitmap" name="platform/frameworks/opt/bitmap" /> -->
   <!-- project path="frameworks/opt/bluetooth" name="platform/frameworks/opt/bluetooth" groups="pdk-cw-fs" /> -->
   <!-- project path="frameworks/opt/calendar" name="platform/frameworks/opt/calendar" groups="pdk-cw-fs" /> -->


### PR DESCRIPTION
This breaks building globally. Everyone who needs it should add it to the
local_manifest (or to the omni.dependencies file) instead of making
everyone remove it if they don't need it (additionally it obviously breaks
building in the default configuration)