### PR TITLE
manifest: Don't track generic device repo and kernel configs

### DIFF
--- a/remove-minimal.xml
+++ b/remove-minimal.xml
@@ -2,6 +2,12 @@
 <manifest>
 
     <!-- Remove from default.xml -->
+    <remove-project name="device/generic/common"/>
+    <remove-project name="device/generic/goldfish"/>
+    <remove-project name="device/generic/goldfish-opengl"/>
+
+    <remove-project name="kernel/configs"/>
+
     <remove-project name="platform/compatibility/cdd"/>
     <remove-project name="platform/cts"/>
 


### PR DESCRIPTION
*We supply our own device trees and kernel to build TWRP
*Not needed in compilation as well