### PR TITLE
fix build error

### DIFF
--- a/remove-minimal.xml
+++ b/remove-minimal.xml
@@ -146,7 +146,7 @@
     <remove-project name="platform/external/nfacct"/>
     <remove-project name="platform/external/nist-pkits"/>
     <!--<remove-project name="platform/external/nist-sip"/>-->
-    <remove-project name="platform/external/noto-fonts"/>
+    <!--<remove-project name="platform/external/noto-fonts"/>-->
     <remove-project name="platform/external/oauth"/>
     <remove-project name="platform/external/objenesis"/>
     <!--<remove-project name="platform/external/okhttp"/>-->
@@ -161,7 +161,7 @@
     <remove-project name="platform/external/replicaisland"/>
     <remove-project name="platform/external/rmi4utils"/>
     <remove-project name="platform/external/robolectric"/>
-    <remove-project name="platform/external/roboto-fonts"/>
+    <!--<remove-project name="platform/external/roboto-fonts"/>-->
     <remove-project name="platform/external/rootdev"/>
     <remove-project name="platform/external/seccomp-tests"/>
     <remove-project name="platform/external/sfntly"/>


### PR DESCRIPTION
On my build environment that is google cloud platform Ubuntu20,04,
I built fail at com.android.recovery.tools.ImageGenerator.loadFontsByLocale(ImageGenerator.java:399).
The error message is "Exception in thread "main" java.io.IOException: Can not find the font file Roboto-Regular for language en"
So, I need font file using minimal manifest.