### PR TITLE
Switch to old repos for system_core and frameworks_base

### DIFF
--- a/omni-aosp.xml
+++ b/omni-aosp.xml
@@ -42,7 +42,7 @@
   <project path="external/toybox" name="android_external_toybox" remote="omnirom" revision="android-9.0" />
 
   <project path="frameworks/av" name="android_frameworks_av" remote="omnirom" revision="android-9.0" />
-  <project path="frameworks/base" name="android_frameworks_base" remote="omnirom" revision="android-9.0" />
+  <project path="frameworks/base" name="android_frameworks_base_old" remote="omnirom" revision="android-9.0" />
   <project path="frameworks/native" name="android_frameworks_native" remote="omnirom" revision="android-9.0" />
   <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="omnirom" revision="android-9.0" />
   <project path="frameworks/opt/net/wifi" name="android_frameworks_opt_net_wifi" remote="omnirom" revision="android-9.0" />
@@ -91,7 +91,7 @@
   <project path="prebuilts/build-tools" name="android_prebuilts_build-tools" remote="omnirom" revision="android-9.0" />
 
   <project path="system/bt" name="android_system_bt" remote="omnirom" revision="android-9.0" />
-  <project path="system/core" name="android_system_core" remote="omnirom" revision="android-9.0" />
+  <project path="system/core" name="android_system_core_old" remote="omnirom" revision="android-9.0" />
   <project path="system/extras" name="android_system_extras" remote="omnirom" revision="android-9.0" />
   <project path="system/libhidl" name="android_system_libhidl" remote="omnirom" revision="android-9.0" />
   <project path="system/media" name="android_system_media" remote="omnirom" revision="android-9.0" />


### PR DESCRIPTION
* All pre android-14 branches of system_core and frameworks_base are moved to system_core_old and frameworks_base_old repos respectively