### PR TITLE
switch to old repo for system_core 10 branch

### DIFF
--- a/omni-aosp.xml
+++ b/omni-aosp.xml
@@ -94,7 +94,7 @@
 
   <project path="system/bpf" name="android_system_bpf" remote="omnirom" revision="android-10" /> -->
   <project path="system/bt" name="android_system_bt" remote="omnirom" revision="android-10" />
-  <project path="system/core" name="android_system_core" remote="omnirom" revision="android-10" />
+  <project path="system/core" name="android_system_core_old" remote="omnirom" revision="android-10" />
   <project path="system/extras" name="android_system_extras" remote="omnirom" revision="android-10" />
   <project path="system/libhidl" name="android_system_libhidl" remote="omnirom" revision="android-10" />
   <project path="system/media" name="android_system_media" remote="omnirom" revision="android-10" />

--- a/twrp-extras.xml
+++ b/twrp-extras.xml
@@ -13,7 +13,7 @@
     <project path="bootable/recovery" name="android_bootable_recovery" remote="TeamWin" revision="android-10.0" />
 
 <!-- Use TeamWin repos for full recovery compatibility -->
-    <remove-project name="android_system_core"/>
+    <remove-project name="android_system_core_old"/>
     <project path="system/core" name="android_system_core" remote="TeamWin" revision="android-10.0" />
 
     <remove-project name="android_vendor_omni"/>


### PR DESCRIPTION
Upstream dependency ( https://github.com/omnirom ) split its repo called `android_system_core`` into `android_system_core` and `android_system_core_old`.`

- `https://github.com/omnirom/android_system_core` contains android >=14
- `https://github.com/omnirom/android_system_core_old` contains android <14

This commit fixes the issues like #129 but for android 10.