### PR TITLE
switch to old repo for system_core and frameworks_base 7.1 branch

### DIFF
--- a/omni-aosp.xml
+++ b/omni-aosp.xml
@@ -36,7 +36,7 @@
   <project path="external/toybox" name="android_external_toybox" remote="omnirom" revision="android-7.1" groups="pdk" />
 
   <project path="frameworks/av" name="android_frameworks_av" remote="omnirom" revision="android-7.1" groups="pdk" />
-  <project path="frameworks/base" name="android_frameworks_base" remote="omnirom" revision="android-7.1" groups="pdk-cw-fs" />
+  <project path="frameworks/base" name="android_frameworks_base_old" remote="omnirom" revision="android-7.1" groups="pdk-cw-fs" />
   <project path="frameworks/ex" name="android_frameworks_ex" remote="omnirom" revision="android-7.1" groups="pdk-cw-fs" />
   <project path="frameworks/native" name="android_frameworks_native" remote="omnirom" revision="android-7.1" groups="pdk" />
   <project path="frameworks/opt/colorpicker" name="android_frameworks_opt_colorpicker" remote="omnirom" revision="android-7.1" groups="pdk-cw-fs" />
@@ -88,7 +88,7 @@
   <project path="packages/services/Telecomm" name="android_packages_services_Telecomm" remote="omnirom" revision="android-7.1" />
   <project path="packages/services/Telephony" name="android_packages_services_Telephony" remote="omnirom" revision="android-7.1" />
 
-  <project path="system/core" name="android_system_core" remote="omnirom" revision="android-7.1" groups="pdk" />
+  <project path="system/core" name="android_system_core_old" remote="omnirom" revision="android-7.1" groups="pdk" />
   <project path="system/extras" name="android_system_extras" remote="omnirom" revision="android-7.1" groups="pdk" />
   <project path="system/media" name="android_system_media" groups="pdk" remote="omnirom" revision="android-7.1" />
   <project path="system/netd" name="android_system_netd" groups="pdk" remote="omnirom" revision="android-7.1" />

--- a/remove-minimal.xml
+++ b/remove-minimal.xml
@@ -15,7 +15,7 @@
   <remove-project name="android_external_tinyalsa" />
   <remove-project name="android_external_tinycompress" />
   <remove-project name="android_frameworks_av" />
-  <remove-project name="android_frameworks_base" />
+  <remove-project name="android_frameworks_base_old" />
   <remove-project name="android_frameworks_ex" />
   <remove-project name="android_frameworks_opt_colorpicker" />
   <remove-project name="android_frameworks_opt_net_ims" />


### PR DESCRIPTION
Upstream dependency ( https://github.com/omnirom ) split its repos and appended the suffix `_old` for everything android <14.

- `https://github.com/omnirom/android_frameworks_base` contains android >=14
- `https://github.com/omnirom/android_frameworks_base_old` contains android <14
- `https://github.com/omnirom/android_system_core` contains android >=14
- `https://github.com/omnirom/android_system_core_old` contains android <14

This commit fixes the same as #124 but for the 7.1 branch